### PR TITLE
Support unnamed extension trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,22 @@ impl<T, E> ResultExt<T, E> for Result<T, E> {
 }
 ```
 
+You can elide the trait name. Note that in this case, `#[ext]` assigns a random name, so you cannot import/export the generated trait.
+
+```rust
+use easy_ext::ext;
+
+#[ext]
+impl<T, E> Result<T, E> {
+    fn err_into<U>(self) -> Result<T, U>
+    where
+        E: Into<U>,
+    {
+        self.map_err(Into::into)
+    }
+}
+```
+
 ### Supported items
 
 * [Methods](https://doc.rust-lang.org/book/ch05-03-method-syntax.html)

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -5,7 +5,7 @@ use easy_ext::ext;
 
 #[test]
 fn test_simple() {
-    #[ext(StrExt)]
+    #[ext]
     impl str {
         fn foo(&self, pat: &str) -> String {
             self.replace(pat, "_")
@@ -17,7 +17,7 @@ fn test_simple() {
 
 #[test]
 fn test_params() {
-    #[ext(ResultExt)]
+    #[ext]
     impl<T, E> Result<T, E> {
         fn err_into<U>(self) -> Result<T, U>
         where

--- a/tests/ui/visibility-3.stderr
+++ b/tests/ui/visibility-3.stderr
@@ -9,3 +9,4 @@ note: the trait `StrExt` is defined here
    |
 4  |     #[ext(StrExt)]
    |     ^^^^^^^^^^^^^^
+   = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
This allows to elide the trait name. Note that in this case, `#[ext]` assigns a random name, so you cannot import/export the generated trait.

```rust
use easy_ext::ext;
#[ext]
impl<T, E> Result<T, E> {
    fn err_into<U>(self) -> Result<T, U>
    where
        E: Into<U>,
    {
        self.map_err(Into::into)
    }
}
```