### PR TITLE
Remove #[inline] from function prototypes

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -143,3 +143,16 @@ fn trait_generics() {
 
     a(A::INIT);
 }
+
+#[test]
+fn inline() {
+    #[ext]
+    impl str {
+        #[inline]
+        fn auto(&self) {}
+        #[inline(always)]
+        fn always(&self) {}
+        #[inline(never)]
+        fn never(&self) {}
+    }
+}


### PR DESCRIPTION
This re-adopts the way used before https://github.com/taiki-e/easy-ext/commit/3234d3db4d62b958ab45e1f9005c2b7fb27c37b1.
Previously only `clippy::inline_fn_without_body` warned about this, now `unused_attributes` also warns about this.

Fixes #21
