### PR TITLE
Support associated types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+- [Support associated types.](https://github.com/taiki-e/easy-ext/pull/26)
+
 ## [0.2.6] - 2021-01-19
 
 - [Support specifying visibility at impl-level.](https://github.com/taiki-e/easy-ext/pull/25)

--- a/README.md
+++ b/README.md
@@ -143,29 +143,44 @@ where
 
 ### Supported items
 
-#### [Associated functions (methods)](https://doc.rust-lang.org/book/ch05-03-method-syntax.html)
+#### [Associated functions (methods)](https://doc.rust-lang.org/reference/items/associated-items.html#associated-functions-and-methods)
 
 ```rust
 use easy_ext::ext;
 
-#[ext(Ext)]
+#[ext]
 impl<T> T {
     fn method(&self) {}
 }
 ```
 
-#### [Associated constants](https://doc.rust-lang.org/edition-guide/rust-2018/trait-system/associated-constants.html)
+#### [Associated constants](https://doc.rust-lang.org/reference/items/associated-items.html#associated-constants)
 
 ```rust
 use easy_ext::ext;
 
-#[ext(Ext)]
+#[ext]
 impl<T> T {
     const MSG: &'static str = "Hello!";
 }
 ```
 
-[rfc0445]: https://github.com/rust-lang/rfcs/blob/master/text/0445-extension-trait-conventions.md
+#### [Associated types](https://doc.rust-lang.org/reference/items/associated-items.html#associated-types)
+
+```rust
+use easy_ext::ext;
+
+#[ext]
+impl str {
+    type Owned = String;
+
+    fn method(&self) -> Self::Owned {
+        self.to_owned()
+    }
+}
+```
+
+[rfc0445]: https://github.com/rust-lang/rfcs/blob/HEAD/text/0445-extension-trait-conventions.md
 
 ## License
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -222,3 +222,33 @@ fn inline() {
         fn multiple(&self) {}
     }
 }
+
+#[test]
+fn assoc_ty() {
+    #[ext(StrExt)]
+    impl str {
+        type Assoc = String;
+
+        fn owned(&self) -> Self::Assoc {
+            self.to_string()
+        }
+    }
+
+    let s: <str as StrExt>::Assoc = "?".owned();
+    assert_eq!(s, "?");
+
+    #[ext(TryIterator)]
+    impl<I: Iterator<Item = Result<T, E>>, T, E> I {
+        type Ok = T;
+        type Error = E;
+
+        fn try_next(&mut self) -> Result<Option<Self::Ok>, Self::Error> {
+            self.next().transpose()
+        }
+    }
+
+    let mut iter = vec![Ok(1), Err(1)].into_iter();
+    assert_eq!(iter.try_next(), Ok(Some(1)));
+    assert_eq!(iter.try_next(), Err(1));
+    assert_eq!(iter.try_next(), Ok(None));
+}


### PR DESCRIPTION
```rust
#[ext]
impl str {
    type Owned = String;

    fn method(&self) -> Self::Owned {
        self.to_owned()
    }
}

#[ext(TryIterator)]
impl<I: Iterator<Item = Result<T, E>>, T, E> I {
    type Ok = T;
    type Error = E;

    fn try_next(&mut self) -> Result<Option<Self::Ok>, Self::Error> {
        self.next().transpose()
    }
}
```