### PR TITLE
Remove dependency on syn/derive feature and direct dependency on quote

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1"
 quote = "1"
-syn = { version = "1.0.56" }
+syn = { version = "1.0.56", default-features = false, features = ["parsing", "printing", "proc-macro"] }
 
 [dev-dependencies]
 async-trait = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,7 @@ proc-macro = true
 
 [dependencies]
 proc-macro2 = "1"
-quote = "1"
-syn = { version = "1.0.56", default-features = false, features = ["parsing", "printing", "proc-macro"] }
+syn = { version = "1.0.56", default-features = false, features = ["parsing", "proc-macro"] }
 
 [dev-dependencies]
 async-trait = "0.1"

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,0 +1,40 @@
+// Based on https://github.com/dtolnay/proc-macro-hack/blob/0.5.18/src/iter.rs
+
+use proc_macro2::{token_stream, Delimiter, TokenStream, TokenTree};
+
+pub(crate) struct TokenIter {
+    stack: Vec<token_stream::IntoIter>,
+    peeked: Option<TokenTree>,
+}
+
+impl TokenIter {
+    pub(crate) fn new(tokens: TokenStream) -> Self {
+        Self { stack: vec![tokens.into_iter()], peeked: None }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn peek(&mut self) -> Option<&TokenTree> {
+        self.peeked = self.next();
+        self.peeked.as_ref()
+    }
+}
+
+impl Iterator for TokenIter {
+    type Item = TokenTree;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(tt) = self.peeked.take() {
+            return Some(tt);
+        }
+        loop {
+            let top = self.stack.last_mut()?;
+            match top.next() {
+                None => drop(self.stack.pop()),
+                Some(TokenTree::Group(ref group)) if group.delimiter() == Delimiter::None => {
+                    self.stack.push(group.stream().into_iter());
+                }
+                Some(tt) => return Some(tt),
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,24 +190,21 @@ macro_rules! error {
 }
 
 mod ast;
+mod iter;
 
 use std::{collections::hash_map::DefaultHasher, hash::Hasher, iter::FromIterator, mem};
 
 use proc_macro::TokenStream;
-use proc_macro2::{Group, Spacing, TokenStream as TokenStream2, TokenTree};
-use quote::{format_ident, quote_spanned, ToTokens};
+use proc_macro2::{Group, Spacing, Span, TokenStream as TokenStream2, TokenTree};
+use quote::{quote, quote_spanned, ToTokens};
 use syn::{
     parse::{Parse, ParseStream},
-    parse_quote,
-    punctuated::Punctuated,
-    Attribute, Error, Expr, GenericArgument, GenericParam, Generics, Ident, Macro, Path,
-    PathArguments, PredicateType, Result, ReturnType, Token, Type, TypeParam, TypeParamBound,
-    TypePath, Visibility, WherePredicate,
+    token, Error, Ident, Result,
 };
 
 use crate::ast::{
-    ImplItem, ItemImpl, ItemTrait, Signature, TraitItem, TraitItemConst, TraitItemMethod,
-    TraitItemType,
+    Attribute, AttributeKind, GenericParam, Generics, ImplItem, ItemImpl, ItemTrait, Signature,
+    TraitItem, TraitItemConst, TraitItemMethod, TraitItemType, TypeParam, Visibility,
 };
 
 /// An attribute macro for easily writing [extension trait pattern][rfc0445].
@@ -219,7 +216,7 @@ use crate::ast::{
 pub fn ext(args: TokenStream, input: TokenStream) -> TokenStream {
     let mut args: Args = syn::parse_macro_input!(args);
     if args.name.is_none() {
-        args.name = Some(format_ident!("__ExtTrait{}", hash(&input)));
+        args.name = Some(Ident::new(&format!("__ExtTrait{}", hash(&input)), Span::call_site()));
     }
 
     let mut item: ItemImpl = syn::parse_macro_input!(input);
@@ -245,41 +242,39 @@ impl Parse for Args {
     fn parse(input: ParseStream<'_>) -> Result<Self> {
         let vis: Visibility = input.parse()?;
         let name: Option<Ident> = input.parse()?;
-        Ok(Args { vis: if let Visibility::Inherited = vis { None } else { Some(vis) }, name })
+        Ok(Args { vis: if vis.is_inherited() { None } else { Some(vis) }, name })
     }
 }
 
-fn determine_trait_generics<'a>(generics: &mut Generics, self_ty: &'a Type) -> Option<&'a Ident> {
-    if let Type::Path(TypePath { path, qself: None }) = self_ty {
-        if let Some(ident) = path.get_ident() {
-            let i = generics.params.iter().position(|param| {
-                if let GenericParam::Type(param) = param { param.ident == *ident } else { false }
-            });
-            if let Some(i) = i {
-                let mut params = mem::replace(&mut generics.params, Punctuated::new())
-                    .into_iter()
-                    .collect::<Vec<_>>();
-                let param = params.remove(i);
-                generics.params = params.into_iter().collect();
+fn determine_trait_generics<'a>(
+    generics: &mut Generics,
+    self_ty: &'a [TokenTree],
+) -> Option<&'a Ident> {
+    if self_ty.len() != 1 {
+        return None;
+    }
+    if let TokenTree::Ident(ident) = &self_ty[0] {
+        let i = generics.params.iter().position(|(param, _)| {
+            if let GenericParam::Type(param) = param { param.ident == *ident } else { false }
+        });
+        if let Some(i) = i {
+            let mut params =
+                mem::replace(&mut generics.params, Vec::new()).into_iter().collect::<Vec<_>>();
+            let (param, _) = params.remove(i);
+            generics.params = params.into_iter().collect();
 
-                if let GenericParam::Type(TypeParam {
-                    colon_token: Some(colon_token),
-                    bounds,
-                    ..
-                }) = param
-                {
-                    generics.make_where_clause().predicates.push(WherePredicate::Type(
-                        PredicateType {
-                            lifetimes: None,
-                            bounded_ty: parse_quote!(Self),
-                            colon_token,
-                            bounds,
-                        },
-                    ));
-                }
-
-                return Some(ident);
+            if let GenericParam::Type(TypeParam {
+                colon_token: Some(colon_token), bounds, ..
+            }) = param
+            {
+                let bounds =
+                    bounds.iter().filter(|(b, _)| !b.is_maybe).map(|(b, p)| quote! { #b #p });
+                generics.make_where_clause().extend(quote! {
+                    Self #colon_token #(#bounds)*
+                });
             }
+
+            return Some(ident);
         }
     }
     None
@@ -292,12 +287,6 @@ fn trait_from_impl(item: &mut ItemImpl, args: Args) -> Result<ItemTrait> {
     }
 
     impl ReplaceParam<'_> {
-        fn visit_ident_mut(&mut self, ident: &mut Ident) {
-            if *ident == *self.self_ty {
-                *ident = Ident::new("Self", ident.span());
-            }
-        }
-
         fn visit_token_stream(&self, tokens: &mut TokenStream2) -> bool {
             let mut out: Vec<TokenTree> = Vec::new();
             let mut modified = false;
@@ -349,7 +338,7 @@ fn trait_from_impl(item: &mut ItemImpl, args: Args) -> Result<ItemTrait> {
         fn visit_trait_item_mut(&mut self, node: &mut TraitItem) {
             match node {
                 TraitItem::Const(node) => {
-                    self.visit_type_mut(&mut node.ty);
+                    self.visit_token_stream(&mut node.ty);
                 }
                 TraitItem::Method(node) => {
                     self.visit_signature_mut(&mut node.sig);
@@ -363,179 +352,24 @@ fn trait_from_impl(item: &mut ItemImpl, args: Args) -> Result<ItemTrait> {
         fn visit_signature_mut(&mut self, node: &mut Signature) {
             self.visit_generics_mut(&mut node.generics);
             self.visit_token_stream(&mut node.inputs);
-            self.visit_return_type_mut(&mut node.output);
-        }
-
-        fn visit_type_mut(&mut self, ty: &mut Type) {
-            match ty {
-                Type::Array(ty) => {
-                    self.visit_type_mut(&mut ty.elem);
-                    self.visit_expr_mut(&mut ty.len);
-                }
-                Type::BareFn(ty) => {
-                    for arg in &mut ty.inputs {
-                        self.visit_type_mut(&mut arg.ty);
-                    }
-                    self.visit_return_type_mut(&mut ty.output);
-                }
-                Type::Group(ty) => {
-                    self.visit_type_mut(&mut ty.elem);
-                }
-                Type::ImplTrait(ty) => {
-                    for bound in &mut ty.bounds {
-                        self.visit_type_param_bound_mut(bound);
-                    }
-                }
-                Type::Macro(ty) => {
-                    self.visit_macro_mut(&mut ty.mac);
-                }
-                Type::Paren(ty) => {
-                    self.visit_type_mut(&mut ty.elem);
-                }
-                Type::Path(ty) => {
-                    if let Some(qself) = &mut ty.qself {
-                        self.visit_type_mut(&mut qself.ty);
-                    }
-                    self.visit_path_mut(&mut ty.path);
-                }
-                Type::Ptr(ty) => {
-                    self.visit_type_mut(&mut ty.elem);
-                }
-                Type::Reference(ty) => {
-                    self.visit_type_mut(&mut ty.elem);
-                }
-                Type::Slice(ty) => {
-                    self.visit_type_mut(&mut ty.elem);
-                }
-                Type::TraitObject(ty) => {
-                    for bound in &mut ty.bounds {
-                        self.visit_type_param_bound_mut(bound);
-                    }
-                }
-                Type::Tuple(ty) => {
-                    for elem in &mut ty.elems {
-                        self.visit_type_mut(elem);
-                    }
-                }
-
-                Type::Infer(_) | Type::Never(_) | Type::Verbatim(_) => {}
-                _ => {}
-            }
-        }
-
-        fn visit_path_mut(&mut self, path: &mut Path) {
-            for segment in &mut path.segments {
-                self.visit_ident_mut(&mut segment.ident);
-                self.visit_path_arguments_mut(&mut segment.arguments);
-            }
-        }
-
-        fn visit_path_arguments_mut(&mut self, arguments: &mut PathArguments) {
-            match arguments {
-                PathArguments::None => {}
-                PathArguments::AngleBracketed(arguments) => {
-                    for arg in &mut arguments.args {
-                        match arg {
-                            GenericArgument::Type(arg) => self.visit_type_mut(arg),
-                            GenericArgument::Binding(arg) => self.visit_type_mut(&mut arg.ty),
-                            GenericArgument::Constraint(arg) => {
-                                for bound in &mut arg.bounds {
-                                    self.visit_type_param_bound_mut(bound);
-                                }
-                            }
-                            GenericArgument::Const(_) | GenericArgument::Lifetime(_) => {}
-                        }
-                    }
-                }
-                PathArguments::Parenthesized(arguments) => {
-                    for argument in &mut arguments.inputs {
-                        self.visit_type_mut(argument);
-                    }
-                    self.visit_return_type_mut(&mut arguments.output);
-                }
-            }
-        }
-
-        fn visit_return_type_mut(&mut self, return_type: &mut ReturnType) {
-            match return_type {
-                ReturnType::Default => {}
-                ReturnType::Type(_, output) => self.visit_type_mut(output),
-            }
-        }
-
-        fn visit_type_param_bound_mut(&mut self, bound: &mut TypeParamBound) {
-            match bound {
-                TypeParamBound::Trait(bound) => self.visit_path_mut(&mut bound.path),
-                TypeParamBound::Lifetime(_) => {}
+            if let Some(ty) = &mut node.output {
+                self.visit_token_stream(ty);
             }
         }
 
         fn visit_generics_mut(&mut self, generics: &mut Generics) {
-            for param in &mut generics.params {
+            for (param, _) in &mut generics.params {
                 match param {
                     GenericParam::Type(param) => {
-                        for bound in &mut param.bounds {
-                            self.visit_type_param_bound_mut(bound);
+                        for (bound, _) in &mut param.bounds {
+                            self.visit_token_stream(&mut bound.tokens);
                         }
                     }
                     GenericParam::Const(_) | GenericParam::Lifetime(_) => {}
                 }
             }
-            if let Some(where_clause) = &mut generics.where_clause {
-                for predicate in &mut where_clause.predicates {
-                    match predicate {
-                        WherePredicate::Type(predicate) => {
-                            self.visit_type_mut(&mut predicate.bounded_ty);
-                            for bound in &mut predicate.bounds {
-                                self.visit_type_param_bound_mut(bound);
-                            }
-                        }
-                        WherePredicate::Lifetime(_) | WherePredicate::Eq(_) => {}
-                    }
-                }
-            }
+            self.visit_token_stream(&mut generics.where_clause);
         }
-
-        fn visit_expr_mut(&mut self, expr: &mut Expr) {
-            match expr {
-                Expr::Binary(expr) => {
-                    self.visit_expr_mut(&mut expr.left);
-                    self.visit_expr_mut(&mut expr.right);
-                }
-                Expr::Call(expr) => {
-                    self.visit_expr_mut(&mut expr.func);
-                    for arg in &mut expr.args {
-                        self.visit_expr_mut(arg);
-                    }
-                }
-                Expr::Cast(expr) => {
-                    self.visit_expr_mut(&mut expr.expr);
-                    self.visit_type_mut(&mut expr.ty);
-                }
-                Expr::Field(expr) => {
-                    self.visit_expr_mut(&mut expr.base);
-                }
-                Expr::Index(expr) => {
-                    self.visit_expr_mut(&mut expr.expr);
-                    self.visit_expr_mut(&mut expr.index);
-                }
-                Expr::Paren(expr) => {
-                    self.visit_expr_mut(&mut expr.expr);
-                }
-                Expr::Path(expr) => {
-                    if let Some(qself) = &mut expr.qself {
-                        self.visit_type_mut(&mut qself.ty);
-                    }
-                    self.visit_path_mut(&mut expr.path);
-                }
-                Expr::Unary(expr) => {
-                    self.visit_expr_mut(&mut expr.expr);
-                }
-                _ => {}
-            }
-        }
-
-        fn visit_macro_mut(&mut self, _mac: &mut Macro) {}
     }
 
     let name = args.name.unwrap();
@@ -546,9 +380,8 @@ fn trait_from_impl(item: &mut ItemImpl, args: Args) -> Result<ItemTrait> {
     if let Some(visitor) = &mut visitor {
         visitor.visit_generics_mut(&mut generics);
     }
-    let ty_generics = generics.split_for_impl().1;
-    let trait_ = parse_quote!(#name #ty_generics);
-    item.trait_ = Some((trait_, <Token![for]>::default()));
+    let ty_generics = generics.ty_generics();
+    item.trait_ = Some(quote! { #name #ty_generics for });
 
     // impl-level visibility
     let impl_vis = args.vis;
@@ -565,18 +398,18 @@ fn trait_from_impl(item: &mut ItemImpl, args: Args) -> Result<ItemTrait> {
     })?;
 
     let mut attrs = item.attrs.clone();
-    find_remove(&mut item.attrs, "doc"); // https://github.com/taiki-e/easy-ext/issues/20
-    attrs.push(parse_quote!(#[allow(patterns_in_fns_without_body)])); // mut self
+    find_remove(&mut item.attrs, AttributeKind::Doc); // https://github.com/taiki-e/easy-ext/issues/20
+    attrs.push(Attribute::new(quote!(allow(patterns_in_fns_without_body)))); // mut self
 
     Ok(ItemTrait {
         attrs,
         // priority: impl-level visibility > assoc-item-level visibility > inherited visibility
         vis: impl_vis.unwrap_or_else(|| assoc_vis.unwrap_or(Visibility::Inherited)),
-        unsafety: item.unsafety,
-        trait_token: Token![trait](item.impl_token.span),
+        unsafety: item.unsafety.clone(),
+        trait_token: Ident::new("trait", item.impl_token.span()),
         ident: name,
         generics,
-        brace_token: item.brace_token,
+        brace_token: token::Brace(item.brace_token.span),
         items,
     })
 }
@@ -586,18 +419,6 @@ fn trait_item_from_impl_item(
     prev_vis: &mut Option<Visibility>,
     impl_vis: &Option<Visibility>,
 ) -> Result<TraitItem> {
-    fn compare_visibility(x: &Visibility, y: &Visibility) -> bool {
-        match (x, y) {
-            (Visibility::Public(_), Visibility::Public(_))
-            | (Visibility::Crate(_), Visibility::Crate(_))
-            | (Visibility::Inherited, Visibility::Inherited) => true,
-            (Visibility::Restricted(x), Visibility::Restricted(y)) => {
-                x.to_token_stream().to_string() == y.to_token_stream().to_string()
-            }
-            _ => false,
-        }
-    }
-
     fn check_visibility(
         current: Visibility,
         prev: &mut Option<Visibility>,
@@ -605,7 +426,7 @@ fn trait_item_from_impl_item(
         span: &dyn ToTokens,
     ) -> Result<()> {
         if impl_vis.is_some() {
-            return if let Visibility::Inherited = current {
+            return if current.is_inherited() {
                 Ok(())
             } else {
                 Err(error!(current, "all associated items must have inherited visibility"))
@@ -613,15 +434,14 @@ fn trait_item_from_impl_item(
         }
         match prev {
             None => *prev = Some(current),
-            Some(prev) if compare_visibility(prev, &current) => {}
+            Some(prev) if *prev == current => {}
             Some(prev) => {
-                return if let Visibility::Inherited = prev {
+                return if prev.is_inherited() {
                     Err(error!(current, "all associated items must have inherited visibility"))
                 } else {
                     Err(error!(
-                        if let Visibility::Inherited = current { span } else { &current },
-                        "all associated items must have a visibility of `{}`",
-                        prev.to_token_stream(),
+                        if current.is_inherited() { span } else { &current },
+                        "all associated items must have a visibility of `{}`", prev,
                     ))
                 };
             }
@@ -635,14 +455,14 @@ fn trait_item_from_impl_item(
             check_visibility(vis, prev_vis, impl_vis, &impl_const.ident)?;
 
             let attrs = impl_const.attrs.clone();
-            find_remove(&mut impl_const.attrs, "doc"); // https://github.com/taiki-e/easy-ext/issues/20
+            find_remove(&mut impl_const.attrs, AttributeKind::Doc); // https://github.com/taiki-e/easy-ext/issues/20
             Ok(TraitItem::Const(TraitItemConst {
                 attrs,
-                const_token: impl_const.const_token,
+                const_token: impl_const.const_token.clone(),
                 ident: impl_const.ident.clone(),
-                colon_token: impl_const.colon_token,
+                colon_token: impl_const.colon_token.clone(),
                 ty: impl_const.ty.clone(),
-                semi_token: impl_const.semi_token,
+                semi_token: impl_const.semi_token.clone(),
             }))
         }
         ImplItem::Type(impl_type) => {
@@ -650,13 +470,13 @@ fn trait_item_from_impl_item(
             check_visibility(vis, prev_vis, impl_vis, &impl_type.ident)?;
 
             let attrs = impl_type.attrs.clone();
-            find_remove(&mut impl_type.attrs, "doc"); // https://github.com/taiki-e/easy-ext/issues/20
+            find_remove(&mut impl_type.attrs, AttributeKind::Doc); // https://github.com/taiki-e/easy-ext/issues/20
             Ok(TraitItem::Type(TraitItemType {
                 attrs,
-                type_token: impl_type.type_token,
+                type_token: impl_type.type_token.clone(),
                 ident: impl_type.ident.clone(),
                 generics: impl_type.generics.clone(),
-                semi_token: impl_type.semi_token,
+                semi_token: impl_type.semi_token.clone(),
             }))
         }
         ImplItem::Method(impl_method) => {
@@ -664,19 +484,19 @@ fn trait_item_from_impl_item(
             check_visibility(vis, prev_vis, impl_vis, &impl_method.sig.ident)?;
 
             let mut attrs = impl_method.attrs.clone();
-            find_remove(&mut impl_method.attrs, "doc"); // https://github.com/taiki-e/easy-ext/issues/20
-            find_remove(&mut attrs, "inline"); // `#[inline]` is ignored on function prototypes
+            find_remove(&mut impl_method.attrs, AttributeKind::Doc); // https://github.com/taiki-e/easy-ext/issues/20
+            find_remove(&mut attrs, AttributeKind::Inline); // `#[inline]` is ignored on function prototypes
             Ok(TraitItem::Method(TraitItemMethod {
                 attrs,
                 sig: impl_method.sig.clone(),
-                semi_token: Token![;](impl_method.brace_token.span),
+                semi_token: ast::printing::punct(';', impl_method.body.span()),
             }))
         }
     }
 }
 
-fn find_remove(attrs: &mut Vec<Attribute>, ident: &str) {
-    while let Some(i) = attrs.iter().position(|attr| attr.path.is_ident(ident)) {
+fn find_remove(attrs: &mut Vec<Attribute>, kind: AttributeKind) {
+    while let Some(i) = attrs.iter().position(|attr| attr.kind == kind) {
         attrs.remove(i);
     }
 }

--- a/src/quote.rs
+++ b/src/quote.rs
@@ -1,0 +1,185 @@
+// Based on https://github.com/dtolnay/proc-macro-hack/blob/0.5.19/src/quote.rs
+
+use std::iter;
+
+use proc_macro2::{Group, Ident, Literal, Punct, Spacing, Span, TokenStream, TokenTree};
+use syn::Lifetime;
+
+macro_rules! quote {
+    () => {
+        ::proc_macro2::TokenStream::new()
+    };
+    ($($tt:tt)*) => {{
+        let mut tokens = ::proc_macro2::TokenStream::new();
+        quote_each_token!(tokens $($tt)*);
+        tokens
+    }};
+}
+
+macro_rules! quote_each_token {
+    ($tokens:ident # $var:ident $($rest:tt)*) => {
+        $crate::quote::ToTokens::to_tokens(&$var, &mut $tokens);
+        quote_each_token!($tokens $($rest)*);
+    };
+    ($tokens:ident $ident:ident $($rest:tt)*) => {
+        <::proc_macro2::TokenStream as ::std::iter::Extend<_>>::extend(
+            &mut $tokens,
+            ::std::iter::once(
+                ::proc_macro2::TokenTree::Ident(
+                    ::proc_macro2::Ident::new(
+                        stringify!($ident),
+                        ::proc_macro2::Span::call_site(),
+                    ),
+                ),
+            ),
+        );
+        quote_each_token!($tokens $($rest)*);
+    };
+    ($tokens:ident ( $($inner:tt)* ) $($rest:tt)*) => {
+        <::proc_macro2::TokenStream as ::std::iter::Extend<_>>::extend(
+            &mut $tokens,
+            ::std::iter::once(
+                ::proc_macro2::TokenTree::Group(
+                    ::proc_macro2::Group::new(
+                        ::proc_macro2::Delimiter::Parenthesis,
+                        quote!($($inner)*),
+                    ),
+                ),
+            ),
+        );
+        quote_each_token!($tokens $($rest)*);
+    };
+    ($tokens:ident [ $($inner:tt)* ] $($rest:tt)*) => {
+        <::proc_macro2::TokenStream as ::std::iter::Extend<_>>::extend(
+            &mut $tokens,
+            ::std::iter::once(
+                ::proc_macro2::TokenTree::Group(
+                    ::proc_macro2::Group::new(
+                        ::proc_macro2::Delimiter::Bracket,
+                        quote!($($inner)*),
+                    ),
+                ),
+            ),
+        );
+        quote_each_token!($tokens $($rest)*);
+    };
+    ($tokens:ident { $($inner:tt)* } $($rest:tt)*) => {
+        <::proc_macro2::TokenStream as ::std::iter::Extend<_>>::extend(
+            &mut $tokens,
+            ::std::iter::once(
+                ::proc_macro2::TokenTree::Group(
+                    ::proc_macro2::Group::new(
+                        ::proc_macro2::Delimiter::Brace,
+                        quote!($($inner)*),
+                    ),
+                ),
+            ),
+        );
+        quote_each_token!($tokens $($rest)*);
+    };
+    ($tokens:ident $punct:tt $($rest:tt)*) => {
+        <::proc_macro2::TokenStream as ::std::iter::Extend<_>>::extend(
+            &mut $tokens,
+            stringify!($punct).parse::<::proc_macro2::TokenStream>(),
+        );
+        quote_each_token!($tokens $($rest)*);
+    };
+    ($tokens:ident) => {};
+}
+
+pub(crate) trait ToTokens {
+    fn to_tokens(&self, tokens: &mut TokenStream);
+
+    fn to_token_stream(&self) -> TokenStream {
+        let mut tokens = TokenStream::new();
+        self.to_tokens(&mut tokens);
+        tokens
+    }
+
+    fn span(&self) -> Span {
+        // https://github.com/dtolnay/quote/blob/1.0.9/src/spanned.rs
+        let tokens = self.to_token_stream();
+        let mut iter = tokens.into_iter().filter_map(|tt| {
+            // FIXME: This shouldn't be required, since optimally spans should
+            // never be invalid. This filter_map can probably be removed when
+            // https://github.com/rust-lang/rust/issues/43081 is resolved.
+            let span = tt.span();
+            let debug = format!("{:?}", span);
+            if debug.ends_with("bytes(0..0)") { None } else { Some(span) }
+        });
+
+        let first = match iter.next() {
+            Some(span) => span,
+            None => return Span::call_site(),
+        };
+
+        iter.fold(None, |_prev, next| Some(next)).and_then(|last| first.join(last)).unwrap_or(first)
+    }
+}
+
+impl ToTokens for Ident {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        tokens.extend(iter::once(TokenTree::Ident(self.clone())));
+    }
+}
+
+impl ToTokens for Punct {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        tokens.extend(iter::once(TokenTree::Punct(self.clone())));
+    }
+}
+
+impl ToTokens for Literal {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        tokens.extend(iter::once(TokenTree::Literal(self.clone())));
+    }
+}
+
+impl ToTokens for Group {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        tokens.extend(iter::once(TokenTree::Group(self.clone())));
+    }
+}
+
+impl ToTokens for Lifetime {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let mut apostrophe = Punct::new('\'', Spacing::Joint);
+        apostrophe.set_span(self.apostrophe);
+        apostrophe.to_tokens(tokens);
+        self.ident.to_tokens(tokens);
+    }
+}
+
+impl ToTokens for TokenTree {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        tokens.extend(iter::once(self.clone()));
+    }
+}
+
+impl ToTokens for TokenStream {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        tokens.extend(self.clone());
+    }
+}
+
+impl<T: ToTokens> ToTokens for Option<T> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        if let Some(t) = self {
+            T::to_tokens(t, tokens)
+        }
+    }
+}
+
+impl<T: ?Sized + ToTokens> ToTokens for &T {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        T::to_tokens(self, tokens)
+    }
+}
+
+impl<T: ToTokens> ToTokens for [T] {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        for t in self {
+            T::to_tokens(t, tokens)
+        }
+    }
+}

--- a/src/quote.rs
+++ b/src/quote.rs
@@ -183,3 +183,12 @@ impl<T: ToTokens> ToTokens for [T] {
         }
     }
 }
+
+impl<T: ToTokens> ToTokens for [(T, Option<Punct>)] {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        for (t, p) in self {
+            T::to_tokens(t, tokens);
+            p.to_tokens(tokens);
+        }
+    }
+}

--- a/tests/compiletest.rs
+++ b/tests/compiletest.rs
@@ -11,4 +11,5 @@ fn ui() {
 
     let t = trybuild::TestCases::new();
     t.compile_fail("tests/ui/*.rs");
+    t.pass("tests/run-pass/*.rs");
 }

--- a/tests/run-pass/min_specialization.rs
+++ b/tests/run-pass/min_specialization.rs
@@ -1,0 +1,97 @@
+#![feature(min_specialization)]
+#![feature(trusted_random_access)]
+
+// See also ui/min_specialization.rs.
+
+// https://github.com/rust-lang/rust/blob/7bd62a8f5a4d6d740677aea03c37771258529922/src/test/ui/specialization/min_specialization/implcit-well-formed-bounds.rs
+pub mod implcit_well_formed_bounds {
+    use easy_ext::ext;
+
+    struct OrdOnly<T: Ord>(T);
+
+    #[ext(SpecTrait)]
+    impl<T, U> T {
+        default fn f() {}
+    }
+
+    impl<T: Ord> SpecTrait<()> for OrdOnly<T> {
+        fn f() {}
+    }
+
+    impl<T: Ord> SpecTrait<OrdOnly<T>> for () {
+        fn f() {}
+    }
+
+    impl<T: Ord, U: Ord, V: Ord> SpecTrait<(OrdOnly<T>, OrdOnly<U>)> for &[OrdOnly<V>] {
+        fn f() {}
+    }
+}
+
+// https://github.com/rust-lang/rust/blob/7bd62a8f5a4d6d740677aea03c37771258529922/src/test/ui/specialization/min_specialization/spec-iter.rs
+pub mod spec_iter {
+    use easy_ext::ext;
+
+    #[ext(SpecFromIter)]
+    impl<'a, T: 'a, I: Iterator<Item = &'a T>> I {
+        default fn f(&self) {}
+    }
+
+    // See also spec_iter module in ui/min_specialization.rs.
+    impl<'a, T> SpecFromIter<'a, T> for std::slice::Iter<'a, T> {
+        fn f(&self) {}
+    }
+}
+
+// https://github.com/rust-lang/rust/blob/7bd62a8f5a4d6d740677aea03c37771258529922/src/test/ui/specialization/min_specialization/spec-reference.rs
+pub mod spec_reference {
+    use easy_ext::ext;
+
+    #[ext(MySpecTrait)]
+    impl<T> T {
+        default fn f() {}
+    }
+
+    impl<'a, T: ?Sized> MySpecTrait for &'a T {
+        fn f() {}
+    }
+}
+
+// https://github.com/rust-lang/rust/blob/7bd62a8f5a4d6d740677aea03c37771258529922/src/test/ui/specialization/min_specialization/specialize_on_marker.rs
+pub mod specialize_on_marker {
+    // `FusedIterator` is `rustc_unsafe_specialization_marker` trait:
+    // https://github.com/rust-lang/rust/blob/7bd62a8f5a4d6d740677aea03c37771258529922/library/core/src/iter/traits/marker.rs#L14
+    use std::iter::FusedIterator;
+
+    use easy_ext::ext;
+
+    #[ext(X)]
+    impl<T> T {
+        default fn f() {}
+    }
+
+    impl<T: FusedIterator> X for T {
+        fn f() {}
+    }
+}
+
+// https://github.com/rust-lang/rust/blob/7bd62a8f5a4d6d740677aea03c37771258529922/src/test/ui/specialization/min_specialization/specialize_on_spec_trait.rs
+pub mod specialize_on_spec_trait {
+    // `TrustedRandomAccess` is `rustc_specialization_trait` trait:
+    // https://github.com/rust-lang/rust/blob/8212de8eb18a8cc4ab74074f244c386d5e99b281/library/core/src/iter/adapters/zip.rs#L449
+    use std::iter::TrustedRandomAccess;
+
+    use easy_ext::ext;
+
+    #[ext(X)]
+    impl<T> T {
+        default fn f(&self) {}
+    }
+
+    impl<T: TrustedRandomAccess> X for T {
+        fn f(&self) {
+            let _ = T::MAY_HAVE_SIDE_EFFECT;
+        }
+    }
+}
+
+fn main() {}

--- a/tests/run-pass/visibility.rs
+++ b/tests/run-pass/visibility.rs
@@ -1,0 +1,57 @@
+#![feature(crate_visibility_modifier)]
+
+use easy_ext::ext;
+
+pub struct Pub;
+#[ext]
+impl str {
+    pub const ASSOC: u8 = 1;
+    pub type Assoc = u8;
+    pub fn assoc() {}
+}
+
+pub struct Crate;
+#[ext]
+impl Crate {
+    crate const ASSOC: u8 = 1;
+    crate type Assoc = u8;
+    crate fn assoc() {}
+}
+
+pub struct PubCrate;
+#[ext]
+impl PubCrate {
+    pub(crate) const ASSOC: u8 = 1;
+    pub(crate) type Assoc = u8;
+    pub(crate) fn assoc() {}
+}
+
+pub struct PubSelf;
+#[ext]
+impl PubSelf {
+    pub(self) const ASSOC: u8 = 1;
+    pub(self) type Assoc = u8;
+    pub(self) fn assoc() {}
+}
+
+pub mod m {
+    use easy_ext::ext;
+
+    pub struct PubSuper;
+    #[ext]
+    impl PubSuper {
+        pub(super) const ASSOC: u8 = 1;
+        pub(super) type Assoc = u8;
+        pub(super) fn assoc() {}
+    }
+
+    pub struct PubIn;
+    #[ext]
+    impl PubIn {
+        pub(in super::m) const ASSOC: u8 = 1;
+        pub(in super::m) type Assoc = u8;
+        pub(in super::m) fn assoc() {}
+    }
+}
+
+fn main() {}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -217,6 +217,14 @@ fn trait_generics() {
 }
 
 #[test]
+fn maybe() {
+    #[ext(X)]
+    impl<T: ?Sized> T {
+        fn f(&self) {}
+    }
+}
+
+#[test]
 fn inline() {
     #[ext]
     impl str {
@@ -308,6 +316,15 @@ fn syntax() {
         async fn asyncness(&self) {}
         async unsafe fn unsafe_asyncness(&self) {}
     }
+
+    #[ext(E3)]
+    impl fn() -> () {
+        const FUNC: fn(&str) -> () = str::normal as fn(&str) -> ();
+        type Func = fn() -> fn() -> ();
+        fn func() -> fn() -> fn() -> () {
+            || || {}
+        }
+    }
 }
 
 #[test]
@@ -322,12 +339,32 @@ fn min_const_generics() {
     }
 
     struct S2<const CAP: usize>;
-    impl<const CAP: usize> E1<(), CAP> for S2<CAP> {
+    impl<const CAP: usize> E1<(), { CAP }> for S2<{ CAP }> {
         const CAPACITY: usize = CAP;
-        fn f<const C: usize>() -> S1<(), C> {
+        fn f<const C: usize>() -> S1<(), { C }> {
             S1([(); C])
         }
     }
 
     let _: [(); 2] = <S2<3>>::f::<2>().0;
+
+    struct S3<T, const CAP: char>(T);
+
+    #[ext(E2)]
+    impl str {
+        fn method1(&self) -> S1<Option<fn() -> ()>, 1> {
+            S1([Some(|| {})])
+        }
+        #[allow(unused_braces)]
+        fn method2(&self) -> S1<Option<fn() -> ()>, { 1 }> {
+            S1([Some(|| {})])
+        }
+        fn method3(&self) -> S3<fn() -> (), 'a'> {
+            S3(|| {})
+        }
+        #[allow(unused_braces)]
+        fn method4(&self) -> S3<fn() -> (), { 'a' }> {
+            S3(|| {})
+        }
+    }
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -216,10 +216,42 @@ fn trait_generics() {
     a(A::INIT2);
 }
 
+// See also ui/maybe.rs
 #[test]
 fn maybe() {
-    #[ext(X)]
+    #[ext]
     impl<T: ?Sized> T {
+        fn f(&self) {}
+    }
+
+    #[ext]
+    impl<T> T
+    where
+        T: ?Sized,
+    {
+        fn f(&self) {}
+    }
+
+    #[ext]
+    impl<T: Send + ?Sized + Sync> T {
+        fn f(&self) {}
+    }
+
+    #[ext]
+    impl<T> T
+    where
+        T: Send + ?Sized + Sync,
+    {
+        fn f(&self) {}
+    }
+
+    #[ext]
+    impl<T> T
+    where
+        T: Iterator,
+        T: ?Sized,
+        T: Default,
+    {
         fn f(&self) {}
     }
 }

--- a/tests/ui/invalid.stderr
+++ b/tests/ui/invalid.stderr
@@ -10,7 +10,7 @@ error: expected `=`
 10 |         type Assoc; //~ ERROR expected `=`
    |                   ^
 
-error: expected curly braces
+error: expected `{`
   --> $DIR/invalid.rs:14:19
    |
 14 |         fn assoc(); //~ ERROR expected curly braces

--- a/tests/ui/maybe.rs
+++ b/tests/ui/maybe.rs
@@ -1,0 +1,76 @@
+// See also `maybe` test in test.rs
+
+use easy_ext::ext;
+
+#[ext(E1)]
+impl<T: ?Sized> T // Ok
+{
+    fn f(&self) {}
+}
+
+#[ext(E2)]
+impl<T> T
+where
+    T: ?Sized, // Ok
+{
+    fn f(&self) {}
+}
+
+#[ext(E3)]
+impl<T> T
+where
+    Self: ?Sized, //~ ERROR `?Trait` bounds are only permitted at the point where a type parameter is declared
+{
+    fn f(&self) {}
+}
+
+// The following is a case where #[ext] is not used. The behavior should match in both cases.
+
+trait T1
+where
+    Self: ?Sized,
+{
+    //~^^ ERROR `?Trait` bounds are only permitted at the point where a type parameter is declared
+    fn f(&self);
+}
+
+trait T2 {
+    fn f(&self);
+}
+impl<T> T2 for T
+where
+    Self: ?Sized, //~ ERROR `?Trait` bounds are only permitted at the point where a type parameter is declared
+{
+    fn f(&self) {}
+}
+
+trait T3 {
+    fn f(&self);
+}
+impl<T: ?Sized> T3 for T // Ok
+{
+    fn f(&self) {}
+}
+
+trait T4 {
+    fn f(&self);
+}
+impl<T> T4 for T
+where
+    T: ?Sized, // Ok
+{
+    fn f(&self) {}
+}
+
+trait T5 {
+    fn f(&self);
+}
+impl<T> T5 for T {
+    fn f(&self)
+    where
+        T: ?Sized, //~ ERROR `?Trait` bounds are only permitted at the point where a type parameter is declared
+    {
+    }
+}
+
+fn main() {}

--- a/tests/ui/maybe.stderr
+++ b/tests/ui/maybe.stderr
@@ -1,0 +1,23 @@
+error: `?Trait` bounds are only permitted at the point where a type parameter is declared
+  --> $DIR/maybe.rs:22:5
+   |
+22 |     Self: ?Sized, //~ ERROR `?Trait` bounds are only permitted at the point where a type parameter is declared
+   |     ^^^^
+
+error: `?Trait` bounds are only permitted at the point where a type parameter is declared
+  --> $DIR/maybe.rs:31:5
+   |
+31 |     Self: ?Sized,
+   |     ^^^^
+
+error: `?Trait` bounds are only permitted at the point where a type parameter is declared
+  --> $DIR/maybe.rs:42:5
+   |
+42 |     Self: ?Sized, //~ ERROR `?Trait` bounds are only permitted at the point where a type parameter is declared
+   |     ^^^^
+
+error: `?Trait` bounds are only permitted at the point where a type parameter is declared
+  --> $DIR/maybe.rs:71:9
+   |
+71 |         T: ?Sized, //~ ERROR `?Trait` bounds are only permitted at the point where a type parameter is declared
+   |         ^

--- a/tests/ui/min_specialization.rs
+++ b/tests/ui/min_specialization.rs
@@ -16,6 +16,7 @@ pub mod spec_iter {
     // To fix compile error, you will need to add `'a` to `SpecFromIter`.
     // See also spec_iter module in run-pass/min_specialization.rs.
     impl<'a, T> SpecFromIter<T> for std::slice::Iter<'a, T> {
+        //~^ ERROR E0726,E0495
         fn f(&self) {}
     }
 }

--- a/tests/ui/min_specialization.rs
+++ b/tests/ui/min_specialization.rs
@@ -1,0 +1,23 @@
+#![feature(min_specialization)]
+
+// See also run-pass/min_specialization.rs.
+
+// https://github.com/rust-lang/rust/blob/7bd62a8f5a4d6d740677aea03c37771258529922/src/test/ui/specialization/min_specialization/spec-iter.rs
+pub mod spec_iter {
+    use easy_ext::ext;
+
+    #[ext(SpecFromIter)]
+    impl<'a, T: 'a, I: Iterator<Item = &'a T>> I {
+        default fn f(&self) {}
+    }
+
+    // This will not compile because all of the generics in the default
+    // implementation are used in the generics of the trait.
+    // To fix compile error, you will need to add `'a` to `SpecFromIter`.
+    // See also spec_iter module in run-pass/min_specialization.rs.
+    impl<'a, T> SpecFromIter<T> for std::slice::Iter<'a, T> {
+        fn f(&self) {}
+    }
+}
+
+fn main() {}

--- a/tests/ui/min_specialization.stderr
+++ b/tests/ui/min_specialization.stderr
@@ -1,15 +1,15 @@
 error[E0726]: implicit elided lifetime not allowed here
-  --> $DIR/min_specialization.rs:17:17
+  --> $DIR/min_specialization.rs:18:17
    |
-17 |     impl<'a, T> SpecFromIter<T> for std::slice::Iter<'a, T> {
+18 |     impl<'a, T> SpecFromIter<T> for std::slice::Iter<'a, T> {
    |                 ^^^^^^^^^^^^^^^ help: indicate the anonymous lifetime: `SpecFromIter<'_, T>`
 
 error[E0495]: cannot infer an appropriate lifetime for lifetime parameter `'a` due to conflicting requirements
    |
-note: first, the lifetime cannot outlive the lifetime `'a` as defined on the impl at 17:10...
-  --> $DIR/min_specialization.rs:17:10
+note: first, the lifetime cannot outlive the lifetime `'a` as defined on the impl at 18:10...
+  --> $DIR/min_specialization.rs:18:10
    |
-17 |     impl<'a, T> SpecFromIter<T> for std::slice::Iter<'a, T> {
+18 |     impl<'a, T> SpecFromIter<T> for std::slice::Iter<'a, T> {
    |          ^^
    = note: ...so that the types are compatible
    = note: expected `Iterator`

--- a/tests/ui/min_specialization.stderr
+++ b/tests/ui/min_specialization.stderr
@@ -1,0 +1,20 @@
+error[E0726]: implicit elided lifetime not allowed here
+  --> $DIR/min_specialization.rs:17:17
+   |
+17 |     impl<'a, T> SpecFromIter<T> for std::slice::Iter<'a, T> {
+   |                 ^^^^^^^^^^^^^^^ help: indicate the anonymous lifetime: `SpecFromIter<'_, T>`
+
+error[E0495]: cannot infer an appropriate lifetime for lifetime parameter `'a` due to conflicting requirements
+   |
+note: first, the lifetime cannot outlive the lifetime `'a` as defined on the impl at 17:10...
+  --> $DIR/min_specialization.rs:17:10
+   |
+17 |     impl<'a, T> SpecFromIter<T> for std::slice::Iter<'a, T> {
+   |          ^^
+   = note: ...so that the types are compatible
+   = note: expected `Iterator`
+              found `Iterator`
+   = note: but, the lifetime must be valid for the static lifetime...
+   = note: ...so that the types are compatible
+   = note: expected `SpecFromIter<'static, T>`
+              found `SpecFromIter<'_, T>`


### PR DESCRIPTION
- Remove dependency on syn/derive, syn/clone, syn/printing features

- Remove direct dependency on quote

- Fix "`?Trait` bounds are only permitted at the point where a type parameter is declared" error

    ```
    error: `?Trait` bounds are only permitted at the point where a type parameter is declared
      --> $DIR/maybe.rs:22:5
       |
    22 |     T: ?Sized,
       |     ^
    ```

cc #28