### PR TITLE
Support `pub impl` syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,6 @@
 
 An attribute macro for easily writing [extension trait pattern][rfc0445].
 
-## Usage
-
-Add this to your `Cargo.toml`:
-
 ```toml
 [dependencies]
 easy-ext = "0.2"
@@ -25,8 +21,8 @@ easy-ext = "0.2"
 use easy_ext::ext;
 
 #[ext(ResultExt)]
-impl<T, E> Result<T, E> {
-    pub fn err_into<U>(self) -> Result<T, U>
+pub impl<T, E> Result<T, E> {
+    fn err_into<U>(self) -> Result<T, U>
     where
         E: Into<U>,
     {
@@ -79,21 +75,20 @@ There are two ways to specify visibility.
 
 #### Impl-level visibility
 
-The first way is to specify visibility as the first argument to the `#[ext]`
-attribute. For example:
+The first way is to specify visibility at the impl level. For example:
 
 ```rust
 use easy_ext::ext;
 
 // unnamed
-#[ext(pub)]
-impl str {
+#[ext]
+pub impl str {
     fn foo(&self) {}
 }
 
 // named
-#[ext(pub StrExt)]
-impl str {
+#[ext(StrExt)]
+pub impl str {
     fn bar(&self) {}
 }
 ```

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -225,6 +225,7 @@ impl fmt::Display for Visibility {
 
 pub(crate) struct ItemImpl {
     pub(crate) attrs: Vec<Attribute>,
+    pub(crate) vis: Visibility,
     defaultness: Option<Ident>,
     pub(crate) unsafety: Option<Ident>,
     pub(crate) impl_token: Ident,
@@ -835,6 +836,7 @@ mod parsing {
     impl Parse for ItemImpl {
         fn parse(input: ParseStream<'_>) -> Result<Self> {
             let attrs = input.call(Attribute::parse_outer)?;
+            let vis: Visibility = input.parse()?;
             let defaultness = parse_kw_opt(input, "default")?;
             let unsafety = parse_kw_opt(input, "unsafe")?;
             let impl_token = parse_kw(&input, "impl")?;
@@ -871,6 +873,7 @@ mod parsing {
 
             Ok(ItemImpl {
                 attrs,
+                vis,
                 defaultness,
                 unsafety,
                 impl_token,

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -57,7 +57,7 @@ mod bar {
     use easy_ext::ext;
 
     // assoc-item-level visibility + named
-    #[ext(StrExt)]
+    #[ext(E1)]
     impl str {
         pub const FOO1: &'static str = "_";
 
@@ -77,8 +77,8 @@ mod bar {
     }
 
     // impl-level visibility + named
-    #[ext(pub StrExt2)]
-    impl str {
+    #[ext(E2)]
+    pub impl str {
         const FOO3: &'static str = "_";
 
         fn foo3(&self, pat: &str) -> String {
@@ -87,8 +87,8 @@ mod bar {
     }
 
     // impl-level visibility + unnamed
-    #[ext(pub)]
-    impl str {
+    #[ext]
+    pub impl str {
         const FOO4: &'static str = "_";
 
         fn foo4(&self, pat: &str) -> String {
@@ -96,17 +96,37 @@ mod bar {
         }
     }
 
+    // impl-level visibility (old syntax) + named
+    #[ext(pub E3)]
+    impl str {
+        const FOO5: &'static str = "_";
+
+        fn foo5(&self, pat: &str) -> String {
+            self.replace(pat, Self::FOO5)
+        }
+    }
+
+    // impl-level visibility (old syntax) + unnamed
+    #[ext(pub)]
+    impl str {
+        const FOO6: &'static str = "_";
+
+        fn foo6(&self, pat: &str) -> String {
+            self.replace(pat, Self::FOO6)
+        }
+    }
+
     pub(super) mod baz {
         use easy_ext::ext;
 
-        #[ext(StrExt3)]
+        #[ext(E4)]
         impl str {
             pub(super) fn bar(&self, pat: &str) -> String {
                 self.replace(pat, "_")
             }
         }
 
-        #[ext(StrExt4)]
+        #[ext(E5)]
         impl str {
             pub fn baz(&self, pat: &str) -> String {
                 self.replace(pat, "_")
@@ -117,14 +137,32 @@ mod bar {
             }
         }
 
-        #[ext(pub(super) StrExt5)]
+        #[ext(E6)]
+        pub(super) impl str {
+            fn bar2(&self, pat: &str) -> String {
+                self.replace(pat, "_")
+            }
+        }
+
+        #[ext(E7)]
+        pub(crate) impl str {
+            fn baz3(&self, pat: &str) -> String {
+                self.replace(pat, "_")
+            }
+
+            fn baz4(&self, pat: &str) -> String {
+                self.replace(pat, "-")
+            }
+        }
+
+        #[ext(pub(super) E8)]
         impl str {
             fn bar2(&self, pat: &str) -> String {
                 self.replace(pat, "_")
             }
         }
 
-        #[ext(pub StrExt6)]
+        #[ext(pub(crate) E9)]
         impl str {
             fn baz3(&self, pat: &str) -> String {
                 self.replace(pat, "_")
@@ -140,12 +178,13 @@ mod bar {
 #[test]
 fn visibility() {
     use self::bar::{
-        baz::{StrExt4, StrExt6},
-        StrExt, StrExt2,
+        baz::{E5, E7},
+        E1, E2, E3,
     };
 
     assert_eq!("..".foo1("."), "__");
     assert_eq!("..".foo3("."), "__");
+    assert_eq!("..".foo5("."), "__");
     assert_eq!("..".baz("."), "__");
     assert_eq!("..".baz2("."), "--");
     assert_eq!("..".baz3("."), "__");

--- a/tests/ui/invalid.rs
+++ b/tests/ui/invalid.rs
@@ -42,11 +42,23 @@ mod visibility {
         pub type Assoc2 = (); //~ ERROR all associated items must have a visibility of `pub(crate)`
     }
 
-    #[ext(pub ImplLevel1)]
+    #[ext(ImplLevel1)]
+    pub impl str {
+        fn assoc1(&self) {}
+
+        pub fn assoc2(&self) {} //~ ERROR all associated items must have inherited visibility
+    }
+
+    #[ext(pub ImplLevel2)]
     impl str {
         fn assoc1(&self) {}
 
         pub fn assoc2(&self) {} //~ ERROR all associated items must have inherited visibility
+    }
+
+    #[ext(pub ImplLevel3)] //~ ERROR visibility can only be specified once
+    pub impl str {
+        fn assoc(&self) {}
     }
 }
 

--- a/tests/ui/invalid.stderr
+++ b/tests/ui/invalid.stderr
@@ -45,3 +45,15 @@ error: all associated items must have inherited visibility
    |
 49 |         pub fn assoc2(&self) {} //~ ERROR all associated items must have inherited visibility
    |         ^^^
+
+error: all associated items must have inherited visibility
+  --> $DIR/invalid.rs:56:9
+   |
+56 |         pub fn assoc2(&self) {} //~ ERROR all associated items must have inherited visibility
+   |         ^^^
+
+error: visibility can only be specified once
+  --> $DIR/invalid.rs:59:11
+   |
+59 |     #[ext(pub ImplLevel3)] //~ ERROR visibility can only be specified once
+   |           ^^^

--- a/tests/ui/visibility.rs
+++ b/tests/ui/visibility.rs
@@ -8,8 +8,8 @@ mod foo {
         }
     }
 
-    #[ext(pub(self) StrExt2)]
-    impl str {
+    #[ext(StrExt2)]
+    pub(self) impl str {
         fn method2(&self, pat: &str) -> String {
             self.replace(pat, "_")
         }
@@ -18,8 +18,8 @@ mod foo {
     pub mod bar {
         use easy_ext::ext;
 
-        #[ext(pub(super) StrExt3)]
-        impl str {
+        #[ext(StrExt3)]
+        pub(super) impl str {
             fn method3(&self, pat: &str) -> String {
                 self.replace(pat, "_")
             }
@@ -32,8 +32,8 @@ mod foo {
 
 fn main() {
     use foo::StrExt1; //~ ERROR trait `StrExt1` is private [E0603]
-
+    let _: ();
     use foo::StrExt2; //~ ERROR trait `StrExt2` is private [E0603]
-
+    let _: ();
     use foo::bar::StrExt3; //~ ERROR trait `StrExt2` is private [E0603]
 }

--- a/tests/ui/visibility.stderr
+++ b/tests/ui/visibility.stderr
@@ -17,16 +17,10 @@ error[E0603]: trait `StrExt2` is private
    |              ^^^^^^^ private trait
    |
 note: the trait `StrExt2` is defined here
-  --> $DIR/visibility.rs:11:11
+  --> $DIR/visibility.rs:12:5
    |
-11 |       #[ext(pub(self) StrExt2)]
-   |  ___________^
-12 | |     impl str {
-13 | |         fn method2(&self, pat: &str) -> String {
-14 | |             self.replace(pat, "_")
-15 | |         }
-16 | |     }
-   | |_____^
+12 |     pub(self) impl str {
+   |     ^^^^^^^^^^^^^^^^^^
 
 error[E0603]: trait `StrExt3` is private
   --> $DIR/visibility.rs:38:19
@@ -35,13 +29,7 @@ error[E0603]: trait `StrExt3` is private
    |                   ^^^^^^^ private trait
    |
 note: the trait `StrExt3` is defined here
-  --> $DIR/visibility.rs:21:15
+  --> $DIR/visibility.rs:22:9
    |
-21 |           #[ext(pub(super) StrExt3)]
-   |  _______________^
-22 | |         impl str {
-23 | |             fn method3(&self, pat: &str) -> String {
-24 | |                 self.replace(pat, "_")
-25 | |             }
-26 | |         }
-   | |_________^
+22 |         pub(super) impl str {
+   |         ^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This replaces the impl-level visibility syntax introduced in https://github.com/taiki-e/easy-ext/pull/25 (v0.2.6). It is more natural syntax and compatible with rustfmt.

```rust
#[ext(Ext)]
pub impl Type {
    fn method(&self) {}
}
```

```text
pub impl Type {
^^^
```

The old impl-level visibility syntax (`#[ext(pub)]`) will still be supported, but it is deprecated and will be removed in the next major version.

Migration:

```diff
- #[ext(pub)]
- impl Type {
+ #[ext]
+ pub impl Type {
    fn method(&self) {}
}
```