### PR TITLE
Support type/const parameter defaults

### DIFF
--- a/tests/run-pass/const_generics_defaults.rs
+++ b/tests/run-pass/const_generics_defaults.rs
@@ -1,0 +1,20 @@
+#![allow(incomplete_features)]
+#![feature(const_generics_defaults)]
+#![feature(custom_inner_attributes)]
+#![rustfmt::skip]
+
+// https://github.com/rust-lang/rust/tree/0ced530534de1a77504b6229e6303d37a12282ee/src/test/ui/const-generics/defaults
+
+use easy_ext::ext;
+
+#[ext(Ext)]
+impl<const N: usize = 3> () {}
+impl Ext for u8 {}
+
+// The code above is equivalent to the code below.
+
+trait Trait<const N: usize = 3> {}
+impl<const N: usize> Trait<N> for () {}
+impl Trait for u8 {}
+
+fn main() {}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -255,6 +255,19 @@ fn trait_generics() {
     a(A::INIT2);
 }
 
+#[test]
+fn type_parameter_defaults() {
+    #[ext(Ext)]
+    impl<T = ()> () {}
+    impl Ext for u8 {}
+
+    // The code above is equivalent to the code below.
+
+    trait Trait<T = ()> {}
+    impl<T> Trait<T> for () {}
+    impl Trait for u8 {}
+}
+
 // See also ui/maybe.rs
 #[test]
 fn maybe() {


### PR DESCRIPTION
```rust
#[ext(Ext)]
impl<T = ()> () {}
impl Ext for u8 {}

// The code above is equivalent to the code below.

trait Trait<T = ()> {}
impl<T> Trait<T> for () {}
impl Trait for u8 {}
```

```rust
#![feature(const_generics_defaults)]

#[ext(Ext)]
impl<const N: usize = 3> () {}
impl Ext for u8 {}

// The code above is equivalent to the code below.

trait Trait<const N: usize = 3> {}
impl<const N: usize> Trait<N> for () {}
impl Trait for u8 {}
```