### PR TITLE
Support const trait impls

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -208,6 +208,7 @@ pub(crate) struct ItemImpl {
     pub(crate) unsafety: Option<Ident>,
     pub(crate) impl_token: Ident,
     pub(crate) generics: Generics,
+    pub(crate) const_token: Option<Ident>,
     pub(crate) trait_: Option<(Ident, TokenStream, Ident)>,
     pub(crate) self_ty: Vec<TokenTree>,
     pub(crate) brace_token: Span,
@@ -851,6 +852,8 @@ mod parsing {
             let mut generics: Generics =
                 if has_generics { input.parse()? } else { Generics::default() };
 
+            let const_token = parse_kw_opt(input, "const")?;
+
             let mut self_ty = vec![];
             append_tokens_until(input, &mut self_ty, false, |next| match next {
                 Some(TokenTree::Group(g)) if g.delimiter() == Delimiter::Brace => true,
@@ -877,6 +880,7 @@ mod parsing {
                 unsafety,
                 impl_token,
                 generics,
+                const_token,
                 trait_: None,
                 self_ty,
                 brace_token: brace_token.span,
@@ -1354,10 +1358,11 @@ pub(crate) mod printing {
             self.unsafety.to_tokens(tokens);
             self.impl_token.to_tokens(tokens);
             self.generics.impl_generics().to_tokens(tokens);
-            if let Some((i, g, f)) = &self.trait_ {
-                i.to_tokens(tokens);
-                g.to_tokens(tokens);
-                f.to_tokens(tokens);
+            self.const_token.to_tokens(tokens);
+            if let Some((path, generics, for_)) = &self.trait_ {
+                path.to_tokens(tokens);
+                generics.to_tokens(tokens);
+                for_.to_tokens(tokens);
             }
             self.self_ty.to_tokens(tokens);
             self.generics.where_clause.to_tokens(tokens);

--- a/tests/run-pass/const_trait_impl.rs
+++ b/tests/run-pass/const_trait_impl.rs
@@ -1,0 +1,22 @@
+#![allow(incomplete_features)]
+#![feature(const_trait_impl)]
+
+// https://github.com/rust-lang/rust/issues/67792
+// https://github.com/rust-lang/rust/blob/49920bc581743d6edb9f82fbff4cbafebc212619/src/test/ui/rfc-2632-const-trait-impl/call-const-trait-method-pass.rs
+
+use easy_ext::ext;
+
+#[ext(Ext)]
+impl const i32 {
+    fn plus(self, rhs: Self) -> Self {
+        self + rhs
+    }
+}
+
+pub const fn add_i32(a: i32, b: i32) -> i32 {
+    a.plus(b)
+}
+
+const ADD_I32: i32 = 1i32.plus(2i32);
+
+fn main() {}


### PR DESCRIPTION
This adds *unstable* (=outside of the normal semver guarantees) support for unstable `feature(const_trait_impl)`.

```rust
#![feature(const_trait_impl)]

use easy_ext::ext;

#[ext(Ext)]
impl const i32 {
    fn plus(self, rhs: Self) -> Self {
        self + rhs
    }
}

pub const fn add_i32(a: i32, b: i32) -> i32 {
    a.plus(b)
}

const ADD_I32: i32 = 1i32.plus(2i32);
```