### PR TITLE
Remove deprecated old impl-level visibility syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+- Remove deprecated old impl-level visibility syntax (`#[ext(pub)]`).
+
+  Use `pub impl` syntax instead:
+
+  ```diff
+  - #[ext(pub)]
+  - impl Type {
+  + #[ext]
+  + pub impl Type {
+      fn method(&self) {}
+  }
+  ```
+
 ## [0.2.9] - 2021-07-03
 
 - [Fix bug in parsing of where clause.](https://github.com/taiki-e/easy-ext/pull/37)

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -86,26 +86,6 @@ mod bar {
         }
     }
 
-    // impl-level visibility (old syntax) + named
-    #[ext(pub E3)]
-    impl str {
-        const FOO5: &'static str = "_";
-
-        fn foo5(&self, pat: &str) -> String {
-            self.replace(pat, Self::FOO5)
-        }
-    }
-
-    // impl-level visibility (old syntax) + unnamed
-    #[ext(pub)]
-    impl str {
-        const FOO6: &'static str = "_";
-
-        fn foo6(&self, pat: &str) -> String {
-            self.replace(pat, Self::FOO6)
-        }
-    }
-
     pub(super) mod baz {
         use easy_ext::ext;
 
@@ -144,24 +124,6 @@ mod bar {
                 self.replace(pat, "-")
             }
         }
-
-        #[ext(pub(super) E8)]
-        impl str {
-            fn bar2(&self, pat: &str) -> String {
-                self.replace(pat, "_")
-            }
-        }
-
-        #[ext(pub(crate) E9)]
-        impl str {
-            fn baz3(&self, pat: &str) -> String {
-                self.replace(pat, "_")
-            }
-
-            fn baz4(&self, pat: &str) -> String {
-                self.replace(pat, "-")
-            }
-        }
     }
 }
 
@@ -169,12 +131,11 @@ mod bar {
 fn visibility() {
     use self::bar::{
         baz::{E5, E7},
-        E1, E2, E3,
+        E1, E2,
     };
 
     assert_eq!("..".foo1("."), "__");
     assert_eq!("..".foo3("."), "__");
-    assert_eq!("..".foo5("."), "__");
     assert_eq!("..".baz("."), "__");
     assert_eq!("..".baz2("."), "--");
     assert_eq!("..".baz3("."), "__");

--- a/tests/ui/invalid.rs
+++ b/tests/ui/invalid.rs
@@ -18,6 +18,16 @@ mod basic {
     impl str {
         mac!(); //~ ERROR expected one of: `default`, `fn`, `const`, `type`
     }
+
+    #[rustfmt::skip]
+    #[ext(ExtraArg,)] //~ ERROR unexpected token: `,`
+    impl str {}
+
+    #[ext(pub OldVisSyntax1)] //~ ERROR use `pub impl` instead
+    impl str {}
+
+    #[ext(pub(crate) OldVisSyntax2)] //~ ERROR use `pub(crate) impl` instead
+    impl str {}
 }
 
 mod visibility {
@@ -47,18 +57,6 @@ mod visibility {
         fn assoc1(&self) {}
 
         pub fn assoc2(&self) {} //~ ERROR all associated items must have inherited visibility
-    }
-
-    #[ext(pub ImplLevel2)]
-    impl str {
-        fn assoc1(&self) {}
-
-        pub fn assoc2(&self) {} //~ ERROR all associated items must have inherited visibility
-    }
-
-    #[ext(pub ImplLevel3)] //~ ERROR visibility can only be specified once
-    pub impl str {
-        fn assoc(&self) {}
     }
 }
 

--- a/tests/ui/invalid.stderr
+++ b/tests/ui/invalid.stderr
@@ -22,38 +22,44 @@ error: expected one of: `default`, `fn`, `const`, `type`
 19 |         mac!(); //~ ERROR expected one of: `default`, `fn`, `const`, `type`
    |         ^^^
 
-error: all associated items must have a visibility of `pub`
-  --> $DIR/invalid.rs:29:15
+error: unexpected token: `,`
+  --> $DIR/invalid.rs:23:19
    |
-29 |         const ASSOC2: u8 = 2; //~ ERROR all associated items must have a visibility of `pub`
+23 |     #[ext(ExtraArg,)] //~ ERROR unexpected token: `,`
+   |                   ^
+
+error: use `pub impl` instead
+  --> $DIR/invalid.rs:26:11
+   |
+26 |     #[ext(pub OldVisSyntax1)] //~ ERROR use `pub impl` instead
+   |           ^^^
+
+error: use `pub(crate) impl` instead
+  --> $DIR/invalid.rs:29:11
+   |
+29 |     #[ext(pub(crate) OldVisSyntax2)] //~ ERROR use `pub(crate) impl` instead
+   |           ^^^^^^^^^^
+
+error: all associated items must have a visibility of `pub`
+  --> $DIR/invalid.rs:39:15
+   |
+39 |         const ASSOC2: u8 = 2; //~ ERROR all associated items must have a visibility of `pub`
    |               ^^^^^^
 
 error: all associated items must have inherited visibility
-  --> $DIR/invalid.rs:36:9
+  --> $DIR/invalid.rs:46:9
    |
-36 |         pub fn assoc2(&self) {} //~ ERROR all associated items must have inherited visibility
+46 |         pub fn assoc2(&self) {} //~ ERROR all associated items must have inherited visibility
    |         ^^^
 
 error: all associated items must have a visibility of `pub(crate)`
-  --> $DIR/invalid.rs:42:9
+  --> $DIR/invalid.rs:52:9
    |
-42 |         pub type Assoc2 = (); //~ ERROR all associated items must have a visibility of `pub(crate)`
+52 |         pub type Assoc2 = (); //~ ERROR all associated items must have a visibility of `pub(crate)`
    |         ^^^
 
 error: all associated items must have inherited visibility
-  --> $DIR/invalid.rs:49:9
+  --> $DIR/invalid.rs:59:9
    |
-49 |         pub fn assoc2(&self) {} //~ ERROR all associated items must have inherited visibility
+59 |         pub fn assoc2(&self) {} //~ ERROR all associated items must have inherited visibility
    |         ^^^
-
-error: all associated items must have inherited visibility
-  --> $DIR/invalid.rs:56:9
-   |
-56 |         pub fn assoc2(&self) {} //~ ERROR all associated items must have inherited visibility
-   |         ^^^
-
-error: visibility can only be specified once
-  --> $DIR/invalid.rs:59:11
-   |
-59 |     #[ext(pub ImplLevel3)] //~ ERROR visibility can only be specified once
-   |           ^^^

--- a/tests/ui/visibility.rs
+++ b/tests/ui/visibility.rs
@@ -31,9 +31,10 @@ mod foo {
 }
 
 fn main() {
+    #[rustfmt::skip]
     use foo::StrExt1; //~ ERROR trait `StrExt1` is private [E0603]
-    let _: ();
+    #[rustfmt::skip]
     use foo::StrExt2; //~ ERROR trait `StrExt2` is private [E0603]
-    let _: ();
+    #[rustfmt::skip]
     use foo::bar::StrExt3; //~ ERROR trait `StrExt2` is private [E0603]
 }

--- a/tests/ui/visibility.stderr
+++ b/tests/ui/visibility.stderr
@@ -1,7 +1,7 @@
 error[E0603]: trait `StrExt1` is private
-  --> $DIR/visibility.rs:34:14
+  --> $DIR/visibility.rs:35:14
    |
-34 |     use foo::StrExt1; //~ ERROR trait `StrExt1` is private [E0603]
+35 |     use foo::StrExt1; //~ ERROR trait `StrExt1` is private [E0603]
    |              ^^^^^^^ private trait
    |
 note: the trait `StrExt1` is defined here
@@ -11,9 +11,9 @@ note: the trait `StrExt1` is defined here
    |     ^^^^^^^^
 
 error[E0603]: trait `StrExt2` is private
-  --> $DIR/visibility.rs:36:14
+  --> $DIR/visibility.rs:37:14
    |
-36 |     use foo::StrExt2; //~ ERROR trait `StrExt2` is private [E0603]
+37 |     use foo::StrExt2; //~ ERROR trait `StrExt2` is private [E0603]
    |              ^^^^^^^ private trait
    |
 note: the trait `StrExt2` is defined here
@@ -23,9 +23,9 @@ note: the trait `StrExt2` is defined here
    |     ^^^^^^^^^^^^^^^^^^
 
 error[E0603]: trait `StrExt3` is private
-  --> $DIR/visibility.rs:38:19
+  --> $DIR/visibility.rs:39:19
    |
-38 |     use foo::bar::StrExt3; //~ ERROR trait `StrExt2` is private [E0603]
+39 |     use foo::bar::StrExt3; //~ ERROR trait `StrExt2` is private [E0603]
    |                   ^^^^^^^ private trait
    |
 note: the trait `StrExt3` is defined here


### PR DESCRIPTION
This removes deprecated old impl-level visibility syntax (`#[ext(pub)]`).

Use `pub impl` syntax instead:

```diff
- #[ext(pub)]
- impl Type {
+ #[ext]
+ pub impl Type {
    fn method(&self) {}
}
```