### PR TITLE
Support arbitrary self types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -560,11 +560,13 @@ fn trait_item_from_impl_item(
                     let mut sig = impl_method.sig.clone();
                     for arg in &mut sig.inputs {
                         if let FnArg::Typed(pat, ..) = arg {
-                            *pat = std::iter::once(TokenTree::Ident(Ident::new(
-                                "_",
-                                pat.clone().into_iter().next().unwrap().span(),
-                            )))
-                            .collect();
+                            if pat.to_string() != "self" {
+                                *pat = std::iter::once(TokenTree::Ident(Ident::new(
+                                    "_",
+                                    pat.clone().into_iter().next().unwrap().span(),
+                                )))
+                                .collect();
+                            }
                         }
                     }
                     sig

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -9,6 +9,8 @@
     clippy::undocumented_unsafe_blocks
 )]
 
+use std::{pin::Pin, rc::Rc};
+
 use async_trait::async_trait;
 use easy_ext::ext;
 
@@ -640,4 +642,27 @@ fn arg_pat() {
             let _y = y;
         }
     }
+}
+
+#[test]
+fn arbitrary_self_types() {
+    #[ext]
+    #[allow(clippy::needless_arbitrary_self_type)]
+    impl String {
+        fn recv(self: Self) {}
+        fn recv_ref(self: &Self) {}
+        fn recv_mut(self: &mut Self) {}
+        fn recv_rc(self: Rc<Self>) {}
+        fn recv_rc_ref(self: &Rc<Self>) {}
+        fn recv_rc_mut(self: &mut Rc<Self>) {}
+        fn recv_pin_box(self: Pin<Box<Self>>) {}
+    }
+
+    String::default().recv();
+    String::default().recv_ref();
+    String::default().recv_mut();
+    Rc::new(String::default()).recv_rc();
+    Rc::new(String::default()).recv_rc_ref();
+    Rc::new(String::default()).recv_rc_mut();
+    Box::pin(String::default()).recv_pin_box();
 }


### PR DESCRIPTION
Arbitrary self types are currently unsupported due to typed fn arg name elision in generated traits.

```rust
error[E0185]: method `recv_pin_box` has a `self: Pin<Box<String>>` declaration in the impl, but not in the trait
   --> tests/test.rs:652:9
    |
652 |         fn recv_pin_box(self: Pin<Box<Self>>) {}
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |         |
    |         `self: Pin<Box<String>>` used in impl
    |         trait method declared without `self: Pin<Box<String>>`

For more information about this error, try `rustc --explain E0185`.
```

This change skips name elision for arbitrary self types.

Perhaps a better approach would be explicitly modeling arbitrary self types as third FnArg variant, but that would be a far more intrusive change.