### PR TITLE
Support trait-only and impl-only attributes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -457,7 +457,8 @@ fn trait_from_impl(item: &mut ItemImpl, trait_name: Ident) -> Result<ItemTrait> 
     })?;
 
     let mut attrs = item.attrs.clone();
-    find_remove(&mut item.attrs, AttributeKind::Doc); // https://github.com/taiki-e/easy-ext/issues/20
+    find_remove(&mut item.attrs, AttributeKind::TraitOnly);
+    find_remove(&mut attrs, AttributeKind::ImplOnly);
     attrs.push(Attribute::new(vec![
         TokenTree::Ident(Ident::new("allow", Span::call_site())),
         TokenTree::Group(Group::new(
@@ -522,8 +523,9 @@ fn trait_item_from_impl_item(
             let vis = mem::replace(&mut impl_const.vis, Visibility::Inherited);
             check_visibility(vis, prev_vis, impl_vis, &impl_const.ident)?;
 
-            let attrs = impl_const.attrs.clone();
-            find_remove(&mut impl_const.attrs, AttributeKind::Doc); // https://github.com/taiki-e/easy-ext/issues/20
+            let mut attrs = impl_const.attrs.clone();
+            find_remove(&mut impl_const.attrs, AttributeKind::TraitOnly);
+            find_remove(&mut attrs, AttributeKind::ImplOnly);
             Ok(TraitItem::Const(TraitItemConst {
                 attrs,
                 const_token: impl_const.const_token.clone(),
@@ -537,8 +539,9 @@ fn trait_item_from_impl_item(
             let vis = mem::replace(&mut impl_type.vis, Visibility::Inherited);
             check_visibility(vis, prev_vis, impl_vis, &impl_type.ident)?;
 
-            let attrs = impl_type.attrs.clone();
-            find_remove(&mut impl_type.attrs, AttributeKind::Doc); // https://github.com/taiki-e/easy-ext/issues/20
+            let mut attrs = impl_type.attrs.clone();
+            find_remove(&mut impl_type.attrs, AttributeKind::TraitOnly);
+            find_remove(&mut attrs, AttributeKind::ImplOnly);
             Ok(TraitItem::Type(TraitItemType {
                 attrs,
                 type_token: impl_type.type_token.clone(),
@@ -552,8 +555,8 @@ fn trait_item_from_impl_item(
             check_visibility(vis, prev_vis, impl_vis, &impl_method.sig.ident)?;
 
             let mut attrs = impl_method.attrs.clone();
-            find_remove(&mut impl_method.attrs, AttributeKind::Doc); // https://github.com/taiki-e/easy-ext/issues/20
-            find_remove(&mut attrs, AttributeKind::Inline); // `#[inline]` is ignored on function prototypes
+            find_remove(&mut impl_method.attrs, AttributeKind::TraitOnly);
+            find_remove(&mut attrs, AttributeKind::ImplOnly);
             Ok(TraitItem::Method(TraitItemMethod {
                 attrs,
                 sig: {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -666,3 +666,65 @@ fn arbitrary_self_types() {
     Rc::new(String::default()).recv_rc_mut();
     Box::pin(String::default()).recv_pin_box();
 }
+
+#[test]
+fn impl_only_attrs() {
+    #![deny(unused_variables)]
+    #![allow(non_camel_case_types)]
+
+    #[ext(E1)]
+    #[ext_attr(impl_only)]
+    #[allow(unused_variables)]
+    impl str {
+        fn foo(&self) {
+            let x = 0;
+        }
+    }
+
+    #[ext(E2)]
+    impl str {
+        #[ext_attr(impl_only)]
+        #[allow(unused_variables)]
+        fn foo(&self) {
+            let x = 0;
+        }
+    }
+
+    #[ext(not_camel_case)]
+    #[ext_attr(impl_only)]
+    #[deny(non_camel_case_types)]
+    impl str {
+        fn foo(&self) {}
+    }
+}
+
+#[test]
+fn trait_only_attrs() {
+    #![allow(unused_variables)]
+    #![deny(non_camel_case_types)]
+
+    #[ext(E1)]
+    #[ext_attr(trait_only)]
+    #[deny(unused_variables)]
+    impl str {
+        fn foo(&self) {
+            let x = 0;
+        }
+    }
+
+    #[ext(E2)]
+    impl str {
+        #[ext_attr(trait_only)]
+        #[deny(unused_variables)]
+        fn foo(&self) {
+            let x = 0;
+        }
+    }
+
+    #[ext(not_camel_case)]
+    #[ext_attr(trait_only)]
+    #[allow(non_camel_case_types)]
+    impl str {
+        fn foo(&self) {}
+    }
+}


### PR DESCRIPTION
Resolve issue #41 by introducing `#[ext_attr(trait_only)]` and `#[ext_attr(impl_only)]` attributes to specify trait-only and impl-only attributes respectively.

```rust
#[ext(TraitOnlyExample)]
#[ext_attr(trait_only)]
#[my_trait_only_attr]
impl String {
    fn foo(&self) {}
}

#[ext(ImplOnlyExample)]
impl String {
    #[ext_attr(impl_only)]
    #[my_impl_only_attr]
    fn foo(&self) {}
}
```